### PR TITLE
don't setup event when button doesn't exist

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -176,7 +176,7 @@ document.addEventListener( 'DOMContentLoaded', event => {
 
     // Share button not Firefox compatible
       const shareBtn = document.querySelector('.btn-share');
-      shareBtn.addEventListener('click', async () => {
+      shareBtn?.addEventListener('click', async () => {
         try {
           let url = document.location.href;
           await navigator.share({ url: url });


### PR DESCRIPTION
Fixes the next error on pages that don't have the share button (like the start page)

![image](https://github.com/djibe/recommandations-medicales/assets/22427111/265acac7-b421-40e3-a7df-a49bb32dec7b)